### PR TITLE
Allow global db connection for Apache user

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,4 +1,3 @@
-Test
 To cite BIGSdb in publications, please use:
 
 Jolley KA & Maiden MC. BIGSdb: Scalable analysis of bacterial genome variation

--- a/CITATION
+++ b/CITATION
@@ -1,3 +1,4 @@
+Test
 To cite BIGSdb in publications, please use:
 
 Jolley KA & Maiden MC. BIGSdb: Scalable analysis of bacterial genome variation

--- a/lib/BIGSdb/CurateBatchProfileUpdatePage.pm
+++ b/lib/BIGSdb/CurateBatchProfileUpdatePage.pm
@@ -1,5 +1,5 @@
 #Written by Keith Jolley
-#Copyright (c) 2013-2015, University of Oxford
+#Copyright (c) 2013-2016, University of Oxford
 #E-mail: keith.jolley@zoo.ox.ac.uk
 #
 #This file is part of Bacterial Isolate Genome Sequence Database (BIGSdb).
@@ -410,7 +410,7 @@ sub _update {
 			say q(<p>Transaction complete - database updated.</p>);
 		}
 	}
-	say q(<p><a href="$self->{'system'}->{'script_name'}?db=$self->{'instance'}">Back to main page</a></p></div>);
+	say qq(<p><a href="$self->{'system'}->{'script_name'}?db=$self->{'instance'}">Back to main page</a></p></div>);
 	return;
 }
 


### PR DESCRIPTION
Hi,

As we decided to not use user `apache` and its default password to connect to the database using BIGSdb, I though it would be to have a file `db.conf` where we could override default db connection parameters. This file is not mandatory and db connection parameters can still be overridden per database config.xml file.

Let me know what do you think. We're using it in production (`v1.14.1`).

Emmanuel