### PR TITLE
Use variables from configuration files instead

### DIFF
--- a/bigsjobs.pl
+++ b/bigsjobs.pl
@@ -33,10 +33,10 @@ use constant {
 	CONFIG_DIR       => '/etc/bigsdb',
 	LIB_DIR          => '/usr/local/lib',
 	DBASE_CONFIG_DIR => '/etc/bigsdb/dbases',
-	HOST             => 'localhost',
-	PORT             => 5432,
-	USER             => 'bigsdb',
-	PASSWORD         => 'bigsdb'
+	HOST             => undef,
+	PORT             => undef,
+	USER             => undef,
+	PASSWORD         => undef
 };
 #######End Local configuration################################
 use lib (LIB_DIR);

--- a/scripts/maintenance/upload_contigs.pl
+++ b/scripts/maintenance/upload_contigs.pl
@@ -26,9 +26,9 @@ use constant {
 	CONFIG_DIR       => '/etc/bigsdb',
 	LIB_DIR          => '/usr/local/lib',
 	DBASE_CONFIG_DIR => '/etc/bigsdb/dbases',
-	HOST             => 'localhost',
-	PORT             => 5432,
-	USER             => 'apache',
+	HOST             => undef,
+	PORT             => undef,
+	USER             => undef,
 	PASSWORD         => undef
 };
 #######End Local configuration################################


### PR DESCRIPTION
Having, by default, the scripts using the variables from the configurations files allows us to not patch the source when updating, so if possible it would be very useful.