### PR TITLE
Fix config file syntax error

### DIFF
--- a/conf/bigsdb.conf
+++ b/conf/bigsdb.conf
@@ -144,7 +144,7 @@ jobs_db=bigsdb_jobs
 max_load=8
 
 #Do not start web-based tag scanning if load average (over last minute) is 
-greater than value. Set lower than max_load to prevent web scans blocking 
+#greater than value. Set lower than max_load to prevent web scans blocking 
 #normal sequence queries (max_load value is used if not set).
 #max_load_webscan=6
 

--- a/lib/BIGSdb/BaseApplication.pm
+++ b/lib/BIGSdb/BaseApplication.pm
@@ -139,7 +139,7 @@ sub read_config_file {
 	my ( $self, $config_dir ) = @_;
 	my $config = Config::Tiny->read("$config_dir/bigsdb.conf");
 	if ( !defined $config ) {
-		$logger->fatal('bigsdb.conf file is not accessible.');
+		$logger->fatal("Unable to read\\parse bigsdb.conf file. Reason: ". Config::Tiny->errstr);
 		$config = Config::Tiny->new();
 	}
 	foreach my $param ( keys %{ $config->{_} } ) {

--- a/lib/BIGSdb/BaseApplication.pm
+++ b/lib/BIGSdb/BaseApplication.pm
@@ -139,7 +139,7 @@ sub read_config_file {
 	my ( $self, $config_dir ) = @_;
 	my $config = Config::Tiny->read("$config_dir/bigsdb.conf");
 	if ( !defined $config ) {
-		$logger->fatal("Unable to read\\parse bigsdb.conf file. Reason: ". Config::Tiny->errstr);
+		$logger->fatal('Unable to read or parse bigsdb.conf file. Reason: ' . Config::Tiny->errstr);
 		$config = Config::Tiny->new();
 	}
 	foreach my $param ( keys %{ $config->{_} } ) {


### PR DESCRIPTION
After two days of debugging, it turned out this line was mistakenly not commented :-D
The [commit](https://github.com/kjolley/BIGSdb/commit/1bf846d9f9a43e6d48105f34d2884b9a707f3c09) caused the bug is made at 29 days ago, so these releases should be fixed too:
`v_1.25.1`
`v_1.25.0`