### PR TITLE
IsolateQueryPage improvement

### DIFF
--- a/lib/BIGSdb/IsolateQueryPage.pm
+++ b/lib/BIGSdb/IsolateQueryPage.pm
@@ -1360,6 +1360,9 @@ sub _print_provenance_fields {
 				push @{ $group_members->{'General'} }, $field;
 			}
 		}
+  		if ( defined $q->param("prov_value$row") && $q->param("prov_value$row") ne '' ) {
+		    push @$values, $q->optgroup( -name => 'selected', -values => ($q->param("prov_field$row")), -labels => {$q->param("prov_field$row") => $q->param("prov_field$row")});
+		}
 		foreach my $group ( undef, @group_list ) {
 			my $name = $group // 'General';
 			$name =~ s/\|.+$//x;


### PR DESCRIPTION
 if isolates are queried through url, inherit provenance fields from url just like allele designations, instead of defaulting to the first value; id