### PR TITLE
add TMPDIR environment variable usage

### DIFF
--- a/scripts/automation/autotag.pl
+++ b/scripts/automation/autotag.pl
@@ -38,6 +38,7 @@ use lib (LIB_DIR);
 use Getopt::Long qw(:config no_ignore_case);
 use Term::Cap;
 use Parallel::ForkManager;
+use File::Temp qw(tempdir);
 use BIGSdb::Offline::AutoTag;
 my %opts;
 GetOptions(
@@ -125,7 +126,8 @@ if ( $opts{'threads'} && $opts{'threads'} > 1 ) {
 	$script->{'logger'}
 	  ->info("$opts{'d'}:Running Autotagger on $isolate_count isolate$plural ($threads thread$plural)");
 	my $job_id = $script->add_job( 'AutoTag', { temp_init => 1 } );
-	my $pm     = Parallel::ForkManager->new( $opts{'threads'} );
+        my $tmpdir = tempdir(DIR => $ENV{'TMPDIR'});
+        my $pm     = Parallel::ForkManager->new( $opts{'threads'} , $tmpdir);
 
 	foreach my $list (@$lists) {
 

--- a/scripts/automation/scannew.pl
+++ b/scripts/automation/scannew.pl
@@ -38,6 +38,7 @@ use lib (LIB_DIR);
 use Getopt::Long qw(:config no_ignore_case);
 use Term::Cap;
 use Parallel::ForkManager;
+use File::Temp qw(tempdir);
 use BIGSdb::Offline::ScanNew;
 my %opts;
 GetOptions(
@@ -126,7 +127,8 @@ if ( BIGSdb::Utils::is_int( $opts{'threads'} ) && $opts{'threads'} > 1 ) {
 	$script->{'logger'}->info("$opts{'d'}:Running Autodefiner (up to $opts{'threads'} threads)");
 	my $job_id = $script->add_job( 'ScanNew', { temp_init => 1 } );
 	print_header();
-	my $pm = Parallel::ForkManager->new( $opts{'threads'} );
+        my $tmpdir = tempdir(DIR => $ENV{'TMPDIR'});
+        my $pm     = Parallel::ForkManager->new( $opts{'threads'} , $tmpdir);
 
 	foreach my $list (@$lists) {
 


### PR DESCRIPTION
Hi,

In our case, when calling some automation script when the current directory is not writable (sudo ... automation.pl), it will wrote this kind of warning : 
```
Temporary directory "tempdir" doesn't exist or is not a directory. at /usr/local/share/perl5/Parallel/ForkManager.pm line 53.
cannot stat initial working directory for /opt/XYZ: Permission denied at /usr/local/share/perl5/Parallel/ForkManager.pm line 327.
```
To avoid this kind of warning, I add the possibility to create a directory inside the TMPDIR environment variable. 
In case of TMPDIR is None, it will just act as before.