### PR TITLE
add possibility to don't use docker installation for plasmidfinder

### DIFF
--- a/lib/BIGSdb/Plugins/PlasmidFinder.pm
+++ b/lib/BIGSdb/Plugins/PlasmidFinder.pm
@@ -1,6 +1,6 @@
 #PlasmidFinder.pm - PlasmidFinder wrapper for BIGSdb
 #Written by Keith Jolley
-#Copyright (c) 2023-2025, University of Oxford
+#Copyright (c) 2023-2026, University of Oxford
 #E-mail: keith.jolley@biology.ox.ac.uk
 #
 #This file is part of Bacterial Isolate Genome Sequence Database (BIGSdb).
@@ -189,10 +189,23 @@ sub run_job {
 	my $i           = 0;
 	my $progress    = 0;
 
-	if ( !$self->{'config'}->{'plasmidfinder'} ) {
+
+	if (!$self->{'config'}->{'plasmidfinder'} ) {
 		$logger->error('PlasmidFinder is not enabled.');
 		return;
 	}
+        if (!$self->{'config'}->{'plasmidfinder_docker'}  ) {
+                  if (!$self->{'config'}->{'plasmidfinder_path'}) {
+                        $logger->error('PlasmidFinder_path and plasmidfinder_docker had not been set.');
+                        return;
+                }else{
+                        if ( !-e $self->{'config'}->{'plasmidfinder_path'} ) {
+                        	$logger->error("plasmidfinder_path $self->{'config'}->{'plasmidfinder_path'} does not exist.");
+                        	return;
+				}
+                }
+        }
+
 	if ( !$self->{'config'}->{'plasmidfinder_db_path'} ) {
 		$logger->error('plasmidfinder_db_path has not been set.');
 		return;
@@ -232,9 +245,13 @@ sub run_job {
 
 		move( $assembly_file_path, $tmp_dir );
 		my $json_file = "${isolate_id}.json";
-		my $cmd =
-			qq(docker run -u "\$(id -u):\$(id -g)" --rm -v plasmidfinder_db_path:/database -v ${tmp_dir}:/workdir )
-		  . qq(-w /workdir plasmidfinder -i $assembly_filename -o /workdir -j $json_file);
+                my $cmd;
+		if ($self->{'config'}->{'plasmidfinder_docker'} == 1) {
+		    $cmd = qq(docker run -u "\$(id -u):\$(id -g)" --rm -v plasmidfinder_db_path:/database -v ${tmp_dir}:/workdir)
+		          . qq(-w /workdir plasmidfinder -i $assembly_filename -o /workdir -j $json_file);
+		} else {
+		    $cmd = qq($self->{'config'}->{'plasmidfinder_path'} -i ${tmp_dir}/$assembly_filename -o ${tmp_dir} -j ${tmp_dir}/$json_file);
+		}
 		eval { system(qq($cmd 1>/dev/null 2>$error_file)); };
 
 		my $error_ref = BIGSdb::Utils::slurp($error_file);
@@ -475,7 +492,14 @@ sub _print_interface {
 sub _get_version {
 	my ($self) = @_;
 	my $temp_file = "$self->{'config'}->{'secure_tmp_dir'}/${$}_version";
-	eval { system("docker run plasmidfinder -v > $temp_file 2>&1 "); };
+        my $cmd;
+        if ($self->{'config'}->{'plasmidfinder_docker'} == 1) {
+             $cmd = qq(docker run plasmidfinder -v > $temp_file 2>&1);
+        } else {
+             $cmd = qq($self->{'config'}->{'plasmidfinder_path'}  -v > $temp_file 2>&1);
+        }
+        eval { system(($cmd))};
+
 	my $out = BIGSdb::Utils::slurp($temp_file);
 	unlink $temp_file;
 	if ( $$out =~ /^\d+\./x ) {

--- a/scripts/maintenance/update_plasmidfinder.pl
+++ b/scripts/maintenance/update_plasmidfinder.pl
@@ -19,7 +19,7 @@
 #You should have received a copy of the GNU General Public License
 #along with BIGSdb.  If not, see <http://www.gnu.org/licenses/>.
 #
-#Version: 20260105
+#Version: 20260203
 use strict;
 use warnings;
 use 5.010;
@@ -131,8 +131,6 @@ sub check_db {
 	$qry .= q[) ];
 	if ( defined $opts{'last_run_days'} ) {
 		$qry .= qq(AND (lr.timestamp IS NULL OR lr.timestamp < now()-interval '$opts{'last_run_days'} days') );
-	} else {
-		$qry .= q(AND (lr.timestamp IS NULL) );
 	}
 	if ( $opts{'v'} ) {
 		$qry .= qq( AND ss.isolate_id IN (SELECT id FROM $opts{'v'}));
@@ -169,10 +167,15 @@ sub check_db {
 
 		move( $assembly_file_path, $tmp_dir );
 		my $json_file = "${isolate_id}.json";
-		my $cmd =
-			qq(docker run -u "\$(id -u):\$(id -g)" --rm -v plasmidfinder_db_path:/database -v ${tmp_dir}:/workdir )
-		  . qq(-w /workdir plasmidfinder -i $assembly_filename -o /workdir -j $json_file);
-		eval { system(qq($cmd 1>/dev/null 2>$error_file)); };
+                my $cmd;
+                if ($script->{'config'}->{'plasmidfinder_docker'} == 1) {
+                    $cmd = qq(docker run -u "\$(id -u):\$(id -g)" --rm -v plasmidfinder_db_path:/database -v ${tmp_dir}:/workdir)
+                          . qq(-w /workdir plasmidfinder -i $assembly_filename -o /workdir -j $json_file);
+                } else {
+                   $cmd = qq($script->{'config'}->{'plasmidfinder_path'} -i ${tmp_dir}/$assembly_filename -o ${tmp_dir} -j ${tmp_dir}/$json_file);
+                }
+
+                eval { system(qq($cmd 1>/dev/null 2>$error_file)); };
 
 		my $error_ref = BIGSdb::Utils::slurp($error_file);
 		if ( $! || $$error_ref ) {


### PR DESCRIPTION
Hello,

I setup the mecanism to use a local installation instead of a docker installation of plasmidfiner.

I have the following bigsdb.conf concerning plasmidfinder:

```
plasmidfinder=1
plasmidfinder_docker=0
plasmidfinder_path=/opt/bigsdb/wrappers/plasmidfinder/plasmidfinder
plasmidfinder_db_path=/opt/gensoft/exe/PlasmidFinder/3.0.1/share
plasmidfinder_record_limit=1000
plasmidfinder_noweb=0
```


Feel free if you have any question about the PR.

Brice