### PR TITLE
Make OAuth key revocation POST-only

### DIFF
--- a/lib/BIGSdb/UserPage.pm
+++ b/lib/BIGSdb/UserPage.pm
@@ -394,12 +394,16 @@ sub _edit_user {
 	say $q->end_form;
 	if ( $username ne $self->{'username'} ) {
 		my $api_key = $self->_get_api_key( { username => $username } );
-		if ($q->param('toggle_ban')){
+		if ( $q->param('toggle_ban') ) {
 			eval {
-			$self->{'auth_db'}->do('UPDATE api_keys SET ban=? WHERE (dbase,username)=(?,?)',undef,
-			$api_key->{'ban'} ? 'false': 'true',$self->{'system'}->{'db'}, $username);
+				$self->{'auth_db'}->do(
+					'UPDATE api_keys SET ban=? WHERE (dbase,username)=(?,?)',
+					undef,
+					$api_key->{'ban'} ? 'false' : 'true',
+					$self->{'system'}->{'db'}, $username
+				);
 			};
-			if ($@){
+			if ($@) {
 				$logger->error($@);
 				$self->{'auth_db'}->rollback;
 			} else {
@@ -412,16 +416,16 @@ sub _edit_user {
 			say q(<fieldset style="float:left"><legend>API access</legend>);
 			my $status = $api_key->{'ban'} ? 'banned' : 'active';
 			say qq(<p>This user has an API key which is currently $status.<p>);
-			if ($api_key->{'ban'}){
+			if ( $api_key->{'ban'} ) {
 				say q(<p><span class="flag" style="color:#992222;background:#99222215">BANNED</span></p>);
 			}
 			my $action = $api_key->{'ban'} ? 'Unban' : 'Ban';
 			say $q->submit(
-			-name  => 'toggle_ban',
-			-label => "$action API key",
-			-class => 'small_submit',
-			-style => 'margin-left:0.2em'
-		);
+				-name  => 'toggle_ban',
+				-label => "$action API key",
+				-class => 'small_submit',
+				-style => 'margin-left:0.2em'
+			);
 			say q(</fieldset>);
 			say $q->hidden($_) foreach qw(edit user update_user);
 			say $q->end_form;
@@ -916,13 +920,11 @@ sub _api_keys {
 		my $td = 1;
 		foreach my $key (@$keys) {
 			my $revoke = DELETE;
-			my $revoke_form = $q->start_form( -method => 'POST', -style => 'display:inline' )
+			my $revoke_form =
+				$q->start_form( -method => 'POST', -style => 'display:inline' )
 			  . $q->hidden( revoke => $key->{'client_id'} )
-			  . $q->submit(
-				-name  => 'submit_revoke',
-				-value => $revoke,
-				-class => 'action'
-			  )
+			  . q(<button type="submit" name="submit_revoke" style="border:0;padding:0;background:transparent">)
+			  . qq(<span class="action">$revoke</span></button>)
 			  . $q->end_form;
 			$buffer .=
 				qq(<tr class="td$td"><td>$revoke_form</td><td>$key->{'application'}</td>)

--- a/lib/BIGSdb/UserPage.pm
+++ b/lib/BIGSdb/UserPage.pm
@@ -899,7 +899,7 @@ sub _api_keys {
 	if ( $q->param('new_key') ) {
 		$buffer .= $self->_make_new_oauth_key;
 	}
-	if ( $q->param('revoke') ) {
+	if ( $q->request_method eq 'POST' && $q->param('revoke') ) {
 		$buffer .= qq(<script>var active_panel=$self->{'panel'};</script>);
 		$self->_revoke_key;
 
@@ -916,9 +916,16 @@ sub _api_keys {
 		my $td = 1;
 		foreach my $key (@$keys) {
 			my $revoke = DELETE;
+			my $revoke_form = $q->start_form( -method => 'POST', -style => 'display:inline' )
+			  . $q->hidden( revoke => $key->{'client_id'} )
+			  . $q->submit(
+				-name  => 'submit_revoke',
+				-value => $revoke,
+				-class => 'action'
+			  )
+			  . $q->end_form;
 			$buffer .=
-				qq(<tr class="td$td"><td><a href="$self->{'system'}->{'script_name'}?revoke=$key->{'client_id'}" )
-			  . qq(class="action">$revoke</a></td><td>$key->{'application'}</td>)
+				qq(<tr class="td$td"><td>$revoke_form</td><td>$key->{'application'}</td>)
 			  . qq(<td style="font-family:monospace">$key->{'client_id'}</td>)
 			  . qq(<td style="font-family:monospace">$key->{'client_secret'}</td>)
 			  . qq(<td>$key->{'datestamp'}</tr>);


### PR DESCRIPTION
## Summary
Prevent OAuth application key revocation from being triggered by a GET request.

## Changes
- only process key revocation when the request method is `POST`
- replace the revoke link in the API keys table with a small inline POST form

## Why
Revoking an OAuth key changes server state and should not be possible via a simple link target. Requiring POST prevents accidental or cross-site link-triggered revocation.