### PR TITLE
Fix weasyprint issue with stdin and stdout in Reports plugin

### DIFF
--- a/lib/BIGSdb/Plugins/Reports.pm
+++ b/lib/BIGSdb/Plugins/Reports.pm
@@ -232,10 +232,63 @@ sub _generate_report {
 	}
 
 	#Convert to PDF.
-	open( my $make_pdf, '|-', $self->{'config'}->{'weasyprint_path'}, '-', '-' )
-	  || $logger->error("Cannot convert PDF. $!");
-	say $make_pdf $template_output;
-	close $make_pdf;
+    my $tmpdir = tempdir(DIR => $ENV{'TMPDIR'});
+	# Create temp files
+	my ($html_fh, $html_file) = tempfile(
+		DIR    =>  $tmpdir,
+		SUFFIX => '.html',
+		UNLINK => 0,
+	);
+	my ($pdf_fh, $pdf_file) = tempfile(
+		DIR    => $tmpdir,
+		SUFFIX => '.pdf',
+		UNLINK => 0,
+	);
+
+	# Write HTML to temp file
+	binmode $html_fh, ':encoding(utf8)';
+	print $html_fh $template_output;
+	close $html_fh;
+	close $pdf_fh;    # weasyprint writes here
+
+	my $cmd =
+		"$self->{'config'}->{'weasyprint_path'} $html_file $pdf_file";
+
+	my $err_fh = gensym;
+
+	eval {
+		my $pid = open3( my $in_fh, my $out_fh, $err_fh, $cmd );
+		close $in_fh;
+
+		local $/ = undef;
+		my $out = <$out_fh>;
+		my $err = <$err_fh>;
+
+		waitpid( $pid, 0 );
+		my $exit_code = $? >> 8;
+
+		if ($exit_code) {
+			if ($err) {
+				$err =~ s/\s+$//x;
+				$logger->error($err);
+			}
+			$logger->error($out) if $out;
+		}
+	};
+	# Read back generated PDF
+	my $pdf;
+	open my $pdf_in, '<:raw', $pdf_file ;
+
+	local $/;
+	$pdf = <$pdf_in>;
+	close $pdf_in;
+	binmode STDOUT;
+	say $pdf;
+
+	# Clean up temp files
+	unlink $html_file if -e $html_file;
+	unlink $pdf_file  if -e $pdf_file;
+
 	return;
 }
 

--- a/lib/BIGSdb/Plugins/Reports.pm
+++ b/lib/BIGSdb/Plugins/Reports.pm
@@ -29,6 +29,9 @@ use Template;
 use Template::Stash;
 use MIME::Base64 qw(encode_base64);
 use JSON;
+use File::Temp qw(tempdir tempfile);
+use IPC::Open3;
+use Symbol        qw(gensym);
 use Log::Log4perl qw(get_logger);
 my $logger = get_logger('BIGSdb.Plugins');
 
@@ -232,14 +235,15 @@ sub _generate_report {
 	}
 
 	#Convert to PDF.
-    my $tmpdir = tempdir(DIR => $ENV{'TMPDIR'});
+	my $tmpdir = tempdir( DIR => $self->{'config'}->{'secure_tmp_dir'} );
+
 	# Create temp files
-	my ($html_fh, $html_file) = tempfile(
-		DIR    =>  $tmpdir,
+	my ( $html_fh, $html_file ) = tempfile(
+		DIR    => $tmpdir,
 		SUFFIX => '.html',
 		UNLINK => 0,
 	);
-	my ($pdf_fh, $pdf_file) = tempfile(
+	my ( $pdf_fh, $pdf_file ) = tempfile(
 		DIR    => $tmpdir,
 		SUFFIX => '.pdf',
 		UNLINK => 0,
@@ -251,8 +255,7 @@ sub _generate_report {
 	close $html_fh;
 	close $pdf_fh;    # weasyprint writes here
 
-	my $cmd =
-		"$self->{'config'}->{'weasyprint_path'} $html_file $pdf_file";
+	my $cmd = "$self->{'config'}->{'weasyprint_path'} $html_file $pdf_file";
 
 	my $err_fh = gensym;
 
@@ -275,15 +278,11 @@ sub _generate_report {
 			$logger->error($out) if $out;
 		}
 	};
-	# Read back generated PDF
-	my $pdf;
-	open my $pdf_in, '<:raw', $pdf_file ;
 
-	local $/;
-	$pdf = <$pdf_in>;
-	close $pdf_in;
+	# Read back generated PDF
+	my $pdf_ref = BIGSdb::Utils::slurp($pdf_file);
 	binmode STDOUT;
-	say $pdf;
+	say $$pdf_ref;
 
 	# Clean up temp files
 	unlink $html_file if -e $html_file;


### PR DESCRIPTION
Hello,

It fixes  #1115.

I setup all the tmpdir/tmpfile as I already have done in the past to be cleaner.
I use a tmpfile for the html input and the pdf output because it doesn't work for both.
Feel free if you have any question about the PR.
Brice